### PR TITLE
Change wiki subtitle and tweaks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-The oofficial wiki for the Cotton Project, created by Ansraer
+# Cotton Wiki
+
+The official wiki for the Cotton Project, created by Ansraer
 
 [See it in action here!](https://cottonmc.github.io/Wiki/)
 
 ## Building the site on your PC
 The github pages site is automatically updated after each commit. However, if you want to test changes locally you will need to install jekyll on your PC.
 
-1.  Start by openiong bash and making sure that you have ruby installed:
+1.  Start by opening bash and making sure that you have ruby installed:
     ```bash
     $ ruby --version
     > ruby 2.X.X

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site title and subtitle. This is used in _includes/header.html
 title: 'Cotton Wiki'
-subtitle: 'Experiments with jekyll and github pages'
+subtitle: 'The official Cotton project wiki'
 
 # if you wish to integrate disqus on pages set your shortname here
 disqus_shortname: ''


### PR DESCRIPTION
- Changed the wiki subtitle from "Experiments with jekyll and github pages" to "The official Cotton project wiki".
- Added a title to README
- Fixed some typos in README